### PR TITLE
Turn triggers off automatically for HV Panic

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -3584,6 +3584,9 @@ void SwapLongBlock(void* p, int32_t n)
 
 - (void) hvPanicDown
 {
+    if ([self isTriggerON]) {
+        [self hvTriggersOFF];
+    }
     [self setHvPanicFlag:YES];
     [self setHvANextStepValue:0];
     [self setHvBNextStepValue:0];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1418,6 +1418,9 @@ static NSDictionary* xl3Ops;
 
 - (IBAction)hvRampDownAction:(id)sender
 {
+    if ([model isTriggerON]) {
+        [model hvTriggersOFF];
+    }
     if ([hvPowerSupplyMatrix selectedColumn] == 0) {
         [model setHvANextStepValue:0];
     }


### PR DESCRIPTION
This checks if triggers are on and turns them off before a HV panic down or ramp down (crate specific or detector wide). Is there a subtle reason this needs to be more complicated?